### PR TITLE
Removed legacy library loading - 0.1.4.2

### DIFF
--- a/overrides/modules/news/controllers/index.php
+++ b/overrides/modules/news/controllers/index.php
@@ -103,7 +103,7 @@ class o_m_news_c_index extends m_news_c_index
 					, 'col-md-6'
 				)
 			),
-			$this->load->library('comments')->display('news', $news_id)
+			$this->load->comments->display('news', $news_id)
 		);
 	}
 }

--- a/overrides/modules/news/views/index.tpl.php
+++ b/overrides/modules/news/views/index.tpl.php
@@ -7,7 +7,7 @@
 		</div>
 		<div class="box-infos">
 			<div class="autor">
-				<div class="pull-left comments"><i class="fa fa-comments-o"></i><br /><?php echo $NeoFrag->library('comments')->count_comments('news', $news['news_id']); ?></div>
+				<div class="pull-left comments"><i class="fa fa-comments-o"></i><br /><?php echo $NeoFrag->comments->count_comments('news', $news['news_id']); ?></div>
 				<div class="pull-right">
 					<div class="share-content">
 						<div class="share">

--- a/overrides/modules/news/views/suite.tpl.php
+++ b/overrides/modules/news/views/suite.tpl.php
@@ -6,7 +6,7 @@
 		</div>
 		<div class="box-infos">
 			<div class="autor">
-				<div class="pull-left comments"><i class="fa fa-comments-o"></i><br /><?php echo $NeoFrag->library('comments')->count_comments('news', $data['news_id']); ?></div>
+				<div class="pull-left comments"><i class="fa fa-comments-o"></i><br /><?php echo $NeoFrag->comments->count_comments('news', $data['news_id']); ?></div>
 				<div class="pull-right">
 					<div class="share-content">
 						<div class="share">


### PR DESCRIPTION
To allow compatibility with version 0.1.4.2 we
removed legacy library loading for comments $NeoFrag->comments instead of $NeoFrag->library('comments')
